### PR TITLE
Do not track distances concurrently

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/ipni/go-libipni v0.3.1
-	github.com/ipni/ipni-cli v0.0.6
+	github.com/ipni/ipni-cli v0.0.7
 	github.com/libp2p/go-libp2p v0.29.0
 	github.com/prometheus/client_golang v1.14.0
 	go.opentelemetry.io/otel v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/ipld/go-ipld-prime v0.20.0 h1:Ud3VwE9ClxpO2LkCYP7vWPc0Fo+dYdYzgxUJZ3u
 github.com/ipld/go-ipld-prime v0.20.0/go.mod h1:PzqZ/ZR981eKbgdr3y2DJYeD/8bgMawdGVlJDE8kK+M=
 github.com/ipni/go-libipni v0.3.1 h1:zCq9UXrvVL4NAxyumPGHboUAGraNfmkDC16BAoQGrww=
 github.com/ipni/go-libipni v0.3.1/go.mod h1:2zyo+mgV+E1T0n6eGmef7+uEt0awOpIhqONfz9ZPtNo=
-github.com/ipni/ipni-cli v0.0.6 h1:43VYhDeFb87htSMyB2S63kOdRd8HfNvSyV3Q/9G9OGs=
-github.com/ipni/ipni-cli v0.0.6/go.mod h1:HdQO3sZ6o6IpGnHMNojbTTtGbfzKAmfcn0ljc8I+9qw=
+github.com/ipni/ipni-cli v0.0.7 h1:6p0kAY6tgCdt+sLhXehluszxX+qX2pzgjECLGnfkqNE=
+github.com/ipni/ipni-cli v0.0.7/go.mod h1:HdQO3sZ6o6IpGnHMNojbTTtGbfzKAmfcn0ljc8I+9qw=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=

--- a/telemetry.go
+++ b/telemetry.go
@@ -138,11 +138,15 @@ func (tel *Telemetry) showProviderInfo(ctx context.Context, pinfo *model.Provide
 	if pinfo.LastError != "" {
 		fmt.Fprintln(w, "    LastError:", pinfo.LastError)
 	} else {
-		dist := tel.dist[pinfo.AddrInfo.ID]
-		if dist == -1 {
-			fmt.Fprintf(w, "    Distance: exceeded limit %d+", tel.adDepthLimit)
+		dist, ok := tel.dist[pinfo.AddrInfo.ID]
+		if ok {
+			if dist == -1 {
+				fmt.Fprintf(w, "    Distance: exceeded limit %d+", tel.adDepthLimit)
+			} else {
+				fmt.Fprintln(w, "    Distance:", dist)
+			}
 		} else {
-			fmt.Fprintln(w, "    Distance:", dist)
+			fmt.Fprintf(w, "    Distance: unknown")
 		}
 	}
 	fmt.Fprintln(w)


### PR DESCRIPTION
Concurrent tracking takes too much memory, and is not critical for this service.